### PR TITLE
don't nest anchor tags in buttons

### DIFF
--- a/resources/public/index.css
+++ b/resources/public/index.css
@@ -120,7 +120,8 @@ h1, h2, h3, h4, h5, p {
   box-sizing: border-box;
 }
 
-.download-button {
+.download-link {
+  display: inline-block;
   background: transparent;
   border: 1px solid #000;
   color: #000;
@@ -133,17 +134,10 @@ h1, h2, h3, h4, h5, p {
   box-sizing: border-box;
 }
 
-.download-button:hover {
+.download-link:hover {
   background: #000;
   color: #FFF;
-}
-
-.download-button:hover a {
-  color: #FFF;
-}
-.download-link {
   text-decoration: none;
-  color: #000;
 }
 
 @media (min-width: 321px) {

--- a/src/cljs/secrets/app.cljs
+++ b/src/cljs/secrets/app.cljs
@@ -71,11 +71,10 @@
 
 (defn download-link []
   [:div
-   [:button.download-button
-     [:a.download-link
-       {:href (str "https://secrets.audio/music/" (:code @state) "/Tarred_and_Pleasured_By_Agatha_Frisky.zip")
-        :target "_blank"}
-       "Your Secret is Approved, Click Here To Download!"]]])
+    [:a.download-link
+     {:href (str "music/" (:code @state) "/Tarred_and_Pleasured_By_Agatha_Frisky.zip")
+      :target "_blank"}
+     "Your Secret is Approved, Click Here To Download!"]])
 
 (defn header []
   [:div.secrets-app__header


### PR DESCRIPTION
- thought problem was relative link
- in fact it was nesting `a` tag inside of `button`

old way worked in chrome and safari but not firefox.